### PR TITLE
Maven project cleanup

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -16,21 +16,7 @@
         <plugins>
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
-                <configuration>
-                    <bnd combine.self="override"><![CDATA[
-#Always export packages with a @Version annotation
--exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}
-#Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
-]]>
-                    </bnd>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-export-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <failOnChanges>false</failOnChanges>
                     <resolve>false</resolve>
@@ -49,7 +35,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -33,21 +33,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,26 +13,6 @@
     <name>INAETICS PubSub Examples</name>
     <packaging>pom</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -16,20 +16,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
-                <configuration>
-                    <bnd combine.self="override"><![CDATA[
-#Always export packages with a @Version annotation
--exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}
-]]>
-                    </bnd>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/examples/pubsub/common/pom.xml
+++ b/examples/pubsub/common/pom.xml
@@ -17,29 +17,12 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation
 -exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}
 ]]>
                     </bnd>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/pubsub/pom.xml
+++ b/examples/pubsub/pom.xml
@@ -27,22 +27,6 @@
                     </bnd>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/examples/pubsub/publisher/pom.xml
+++ b/examples/pubsub/publisher/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation
@@ -25,22 +24,6 @@
 Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
 ]]>
                     </bnd>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/pubsub/subscriber/pom.xml
+++ b/examples/pubsub/subscriber/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation
@@ -25,22 +24,6 @@
 Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
 ]]>
                     </bnd>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,80 @@
         <bnd-maven-plugin.version>3.5.0</bnd-maven-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
+        <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+        <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
+
         <osgi.version>6.0.0</osgi.version>
     </properties>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-maven-plugin</artifactId>
+                    <version>${bnd-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>biz.aQute.bnd</groupId>
+                    <artifactId>bnd-export-maven-plugin</artifactId>
+                    <version>${bnd-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven-enforcer-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifestFile>${manifest-file}</manifestFile>
@@ -36,7 +102,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <manifestPath>${manifest-file}</manifestPath>
                     <bnd><![CDATA[
@@ -50,6 +115,25 @@
                         <goals>
                             <goal>bnd-process</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-rules</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <rules>
+                                <banDuplicatePomDependencyVersions />
+                                <requirePluginVersions />
+                                <reactorModuleConvergence />
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>.</directory>
+                            <includes>
+                                <include>generated</include>
+                                <include>bin</include>
+                            </includes>
+                            <followSymlinks>false</followSymlinks>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pubsub.api/pom.xml
+++ b/pubsub.api/pom.xml
@@ -15,13 +15,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/pubsub.api/pom.xml
+++ b/pubsub.api/pom.xml
@@ -12,24 +12,4 @@
     <artifactId>org.inaetics.pubsub.api</artifactId>
     <name>INAETICS PubSub API</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/pubsub.discovery.etcd/pom.xml
+++ b/pubsub.discovery.etcd/pom.xml
@@ -27,21 +27,6 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
                     </bnd>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pubsub.discovery.etcd/pom.xml
+++ b/pubsub.discovery.etcd/pom.xml
@@ -18,7 +18,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation
@@ -30,7 +29,6 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/pubsub.psa.zeromq/pom.xml
+++ b/pubsub.psa.zeromq/pom.xml
@@ -17,9 +17,8 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
-                    <bnd combine.self="override"><![CDATA[
+                    <bnd combine.self="append"><![CDATA[
 #Always export packages with a @Version annotation
 -exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}
 Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
@@ -30,7 +29,6 @@ DynamicImport-Package: *
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/pubsub.psa.zeromq/pom.xml
+++ b/pubsub.psa.zeromq/pom.xml
@@ -27,21 +27,6 @@ DynamicImport-Package: *
                     </bnd>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pubsub.serialization.json/pom.xml
+++ b/pubsub.serialization.json/pom.xml
@@ -27,21 +27,6 @@ DynamicImport-Package: *
                     </bnd>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pubsub.serialization.json/pom.xml
+++ b/pubsub.serialization.json/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation
@@ -30,7 +29,6 @@ DynamicImport-Package: *
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/pubsub.spi/pom.xml
+++ b/pubsub.spi/pom.xml
@@ -16,13 +16,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
-            </plugin>
-            <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -48,7 +42,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>RELEASE</version>
+            <version>5.4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pubsub.spi/pom.xml
+++ b/pubsub.spi/pom.xml
@@ -12,27 +12,6 @@
     <artifactId>org.inaetics.pubsub.spi</artifactId>
     <name>INAETICS PubSub SPI</name>
 
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>

--- a/pubsub.topologymanager/pom.xml
+++ b/pubsub.topologymanager/pom.xml
@@ -26,22 +26,6 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
                     </bnd>
                 </configuration>
             </plugin>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>${maven-clean-plugin.version}</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>.</directory>
-                            <includes>
-                                <include>generated</include>
-                                <include>bin</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/pubsub.topologymanager/pom.xml
+++ b/pubsub.topologymanager/pom.xml
@@ -17,7 +17,6 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>${bnd-maven-plugin.version}</version>
                 <configuration>
                     <bnd combine.self="override"><![CDATA[
 #Always export packages with a @Version annotation


### PR DESCRIPTION
Various (minor) POM cleanup changes:

- Ensured that all used plugins are explicitly configured (by means of maven-enforcer-plugin), thus ensuring reproducibility.
- Maintain version management of plugins in the parent pom file
- Put commonly used plugins in the parent pom
- Replace used 'RELEASE' version with an explicit version, thus ensuring reproducibility