### PR TITLE
Dependency cleanup

### DIFF
--- a/deploy/launch.zmq.publisher.bndrun
+++ b/deploy/launch.zmq.publisher.bndrun
@@ -15,41 +15,21 @@
   org.inaetics.pubsub.psa.zeromq.threads=1,\
   org.inaetics.pubsub.psa.zeromq.secure=false
 
--runbundles: \
-  osgi.annotation;version=latest,\
-  osgi.core;version=latest,\
-  org.apache.felix.gogo.runtime, \
-  org.apache.felix.gogo.shell, \
-  org.apache.felix.gogo.command, \
-  org.apache.felix.metatype;version='[1.1.2,2)', \
-  org.apache.felix.http.servlet-api;version='[1.0.0, 1.1)', \
-  org.apache.felix.http.jetty;version=latest,\
-  org.apache.felix.configadmin;version='[1.6.0,1.7)', \
-  org.apache.felix.eventadmin;version='[1.3,2)', \
-  org.apache.felix.log;version='[1.0.1,1.1)', \
-  org.apache.felix.dependencymanager;version=4.4.1, \
-  org.apache.felix.dependencymanager.annotation;version=4.2.1, \
-  org.apache.felix.dependencymanager.shell;version=4.0.6,\
-  biz.aQute.bndlib;version=2.4.1, \
-  org.apache.felix.scr;version='[2.0.12,3)', \
-  org.osgi.service.remoteserviceadmin;version='[1.1.0,1.2)', \
-  slf4j.jdk14;version='[1.7.5,2)', \
-  slf4j.api;version='[1.7.5,2)',\
-  jackson-core-asl;version=latest,\
-  jackson-mapper-asl;version=latest,\
-  com.fasterxml.jackson.core.jackson-databind;version=2.9.2,\
-  com.fasterxml.jackson.core.jackson-annotations;version=2.9.2,\
-  com.fasterxml.jackson.core.jackson-core;version=2.9.2,\
-  org.apache.httpcomponents.httpclient;version=4.5.3,\
-  org.apache.httpcomponents.httpcore;version=4.4.6,\
-  org.apache.commons.logging;version=1.2,\
-  org.zeromq.jeromq;version=0.4.3,\
-  org.zeromq.jnacl;version=0.1.1.SNAPSHOT,\
-  org.inaetics.pubsub.api,\
-  org.inaetics.pubsub.spi,\
-  org.inaetics.pubsub.topologymanager,\
-  org.inaetics.pubsub.discovery.etcd,\
-  org.inaetics.pubsub.serialization.json,\
-  org.inaetics.pubsub.psa.zeromq,\
-  org.inaetics.pubsub.examples.pubsub.common,\
-  org.inaetics.pubsub.examples.pubsub.publisher
+-runrequires: \
+  bnd.identity; id=org.apache.felix.gogo.runtime, \
+  bnd.identity; id=org.apache.felix.gogo.shell, \
+  bnd.identity; id=org.apache.felix.gogo.command, \
+  bnd.identity; id=org.apache.felix.metatype, \
+  bnd.identity; id=org.apache.felix.configadmin, \
+  bnd.identity; id=org.apache.felix.eventadmin, \
+  bnd.identity; id=org.apache.felix.dependencymanager, \
+  bnd.identity; id=org.apache.felix.dependencymanager.shell, \
+  bnd.identity; id=org.apache.felix.log, \
+  bnd.identity; id=org.inaetics.pubsub.api, \
+  bnd.identity; id=org.inaetics.pubsub.spi, \
+  bnd.identity; id=org.inaetics.pubsub.topologymanager, \
+  bnd.identity; id=org.inaetics.pubsub.discovery.etcd, \
+  bnd.identity; id=org.inaetics.pubsub.serialization.json, \
+  bnd.identity; id=org.inaetics.pubsub.psa.zeromq, \
+  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.common, \
+  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.publisher

--- a/deploy/launch.zmq.publisher.bndrun
+++ b/deploy/launch.zmq.publisher.bndrun
@@ -19,17 +19,11 @@
   bnd.identity; id=org.apache.felix.gogo.runtime, \
   bnd.identity; id=org.apache.felix.gogo.shell, \
   bnd.identity; id=org.apache.felix.gogo.command, \
-  bnd.identity; id=org.apache.felix.metatype, \
   bnd.identity; id=org.apache.felix.configadmin, \
-  bnd.identity; id=org.apache.felix.eventadmin, \
-  bnd.identity; id=org.apache.felix.dependencymanager, \
   bnd.identity; id=org.apache.felix.dependencymanager.shell, \
   bnd.identity; id=org.apache.felix.log, \
-  bnd.identity; id=org.inaetics.pubsub.api, \
-  bnd.identity; id=org.inaetics.pubsub.spi, \
   bnd.identity; id=org.inaetics.pubsub.topologymanager, \
   bnd.identity; id=org.inaetics.pubsub.discovery.etcd, \
   bnd.identity; id=org.inaetics.pubsub.serialization.json, \
   bnd.identity; id=org.inaetics.pubsub.psa.zeromq, \
-  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.common, \
   bnd.identity; id=org.inaetics.pubsub.examples.pubsub.publisher

--- a/deploy/launch.zmq.subscriber.bndrun
+++ b/deploy/launch.zmq.subscriber.bndrun
@@ -17,17 +17,11 @@
   bnd.identity; id=org.apache.felix.gogo.runtime, \
   bnd.identity; id=org.apache.felix.gogo.shell, \
   bnd.identity; id=org.apache.felix.gogo.command, \
-  bnd.identity; id=org.apache.felix.metatype, \
   bnd.identity; id=org.apache.felix.configadmin, \
-  bnd.identity; id=org.apache.felix.eventadmin, \
-  bnd.identity; id=org.apache.felix.dependencymanager, \
   bnd.identity; id=org.apache.felix.dependencymanager.shell, \
   bnd.identity; id=org.apache.felix.log, \
-  bnd.identity; id=org.inaetics.pubsub.api, \
-  bnd.identity; id=org.inaetics.pubsub.spi, \
   bnd.identity; id=org.inaetics.pubsub.topologymanager, \
   bnd.identity; id=org.inaetics.pubsub.discovery.etcd, \
   bnd.identity; id=org.inaetics.pubsub.serialization.json, \
   bnd.identity; id=org.inaetics.pubsub.psa.zeromq, \
-  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.common, \
   bnd.identity; id=org.inaetics.pubsub.examples.pubsub.subscriber

--- a/deploy/launch.zmq.subscriber.bndrun
+++ b/deploy/launch.zmq.subscriber.bndrun
@@ -13,41 +13,21 @@
   org.inaetics.pubsub.psa.zeromq.threads=1,\
   org.inaetics.pubsub.psa.zeromq.secure=false
 
--runbundles: \
-  osgi.annotation;version=latest,\
-  osgi.core;version=latest,\
-  org.apache.felix.gogo.runtime, \
-  org.apache.felix.gogo.shell, \
-  org.apache.felix.gogo.command, \
-  org.apache.felix.metatype;version='[1.1.2,2)', \
-  org.apache.felix.http.servlet-api;version='[1.0.0, 1.1)', \
-  org.apache.felix.http.jetty;version=latest,\
-  org.apache.felix.configadmin;version='[1.6.0,1.7)', \
-  org.apache.felix.eventadmin;version='[1.3,2)', \
-  org.apache.felix.log;version='[1.0.1,1.1)', \
-  org.apache.felix.dependencymanager;version=4.4.1, \
-  org.apache.felix.dependencymanager.annotation;version=4.2.1, \
-  org.apache.felix.dependencymanager.shell;version=4.0.6,\
-  biz.aQute.bndlib;version=2.4.1, \
-  org.apache.felix.scr;version='[2.0.12,3)', \
-  org.osgi.service.remoteserviceadmin;version='[1.1.0,1.2)', \
-  slf4j.jdk14;version='[1.7.5,2)', \
-  slf4j.api;version='[1.7.5,2)',\
-  jackson-core-asl;version=latest,\
-  jackson-mapper-asl;version=latest,\
-  com.fasterxml.jackson.core.jackson-databind;version=2.9.2,\
-  com.fasterxml.jackson.core.jackson-annotations;version=2.9.2,\
-  com.fasterxml.jackson.core.jackson-core;version=2.9.2,\
-  org.apache.httpcomponents.httpclient;version=4.5.3,\
-  org.apache.httpcomponents.httpcore;version=4.4.6,\
-  org.apache.commons.logging;version=1.2,\
-  org.zeromq.jeromq;version=0.4.3,\
-  org.zeromq.jnacl;version=0.1.1.SNAPSHOT,\
-  org.inaetics.pubsub.api,\
-  org.inaetics.pubsub.spi,\
-  org.inaetics.pubsub.topologymanager,\
-  org.inaetics.pubsub.discovery.etcd,\
-  org.inaetics.pubsub.serialization.json,\
-  org.inaetics.pubsub.psa.zeromq,\
-  org.inaetics.pubsub.examples.pubsub.common,\
-  org.inaetics.pubsub.examples.pubsub.subscriber
+-runrequires: \
+  bnd.identity; id=org.apache.felix.gogo.runtime, \
+  bnd.identity; id=org.apache.felix.gogo.shell, \
+  bnd.identity; id=org.apache.felix.gogo.command, \
+  bnd.identity; id=org.apache.felix.metatype, \
+  bnd.identity; id=org.apache.felix.configadmin, \
+  bnd.identity; id=org.apache.felix.eventadmin, \
+  bnd.identity; id=org.apache.felix.dependencymanager, \
+  bnd.identity; id=org.apache.felix.dependencymanager.shell, \
+  bnd.identity; id=org.apache.felix.log, \
+  bnd.identity; id=org.inaetics.pubsub.api, \
+  bnd.identity; id=org.inaetics.pubsub.spi, \
+  bnd.identity; id=org.inaetics.pubsub.topologymanager, \
+  bnd.identity; id=org.inaetics.pubsub.discovery.etcd, \
+  bnd.identity; id=org.inaetics.pubsub.serialization.json, \
+  bnd.identity; id=org.inaetics.pubsub.psa.zeromq, \
+  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.common, \
+  bnd.identity; id=org.inaetics.pubsub.examples.pubsub.subscriber

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -101,10 +101,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.eventadmin</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.dependencymanager.shell</artifactId>
         </dependency>
         <dependency>

--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -19,7 +19,7 @@
                 <artifactId>bnd-export-maven-plugin</artifactId>
                 <configuration>
                     <failOnChanges>false</failOnChanges>
-                    <resolve>false</resolve>
+                    <resolve>true</resolve>
                     <bndruns>
                         <bndrun>launch.zmq.publisher.bndrun</bndrun>
                         <bndrun>launch.zmq.subscriber.bndrun</bndrun>
@@ -40,48 +40,76 @@
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.discovery.etcd</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.serialization.json</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.topologymanager</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.psa.zeromq</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.examples.pubsub.common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.examples.pubsub.publisher</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.examples.pubsub.subscriber</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.gogo.runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.gogo.shell</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.gogo.command</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.metatype</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.configadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.eventadmin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager.shell</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.log</artifactId>
         </dependency>
 
     </dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,14 +13,6 @@
     <name>INAETICS PubSub Examples</name>
     <packaging>pom</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.inaetics.pubsub</groupId>
-            <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
-
     <modules>
         <module>pubsub</module>
     </modules>

--- a/examples/pubsub/common/pom.xml
+++ b/examples/pubsub/common/pom.xml
@@ -12,20 +12,15 @@
     <artifactId>org.inaetics.pubsub.examples.pubsub.common</artifactId>
     <name>INAETICS PubSub Examples - Pubsub Common</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-                <configuration>
-                    <bnd combine.self="override"><![CDATA[
-#Always export packages with a @Version annotation
--exportcontents: ${packages;ANNOTATED;org.osgi.annotation.versioning.Version}
-]]>
-                    </bnd>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.inaetics.pubsub</groupId>
+            <artifactId>org.inaetics.pubsub.api</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/examples/pubsub/publisher/pom.xml
+++ b/examples/pubsub/publisher/pom.xml
@@ -33,7 +33,18 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.examples.pubsub.common</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
     </dependencies>
 

--- a/examples/pubsub/subscriber/pom.xml
+++ b/examples/pubsub/subscriber/pom.xml
@@ -33,7 +33,18 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.examples.pubsub.common</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -238,11 +238,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
-                <artifactId>org.apache.felix.eventadmin</artifactId>
-                <version>1.3.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.log</artifactId>
                 <version>1.0.1</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <bnd-maven-plugin.version>3.5.0</bnd-maven-plugin.version>
+        <bnd-maven-plugin.version>4.2.0</bnd-maven-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
         <maven-clean-plugin.version>3.0.0</maven-clean-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
@@ -155,157 +155,173 @@
         </plugins>
     </build>
 
-    <!-- temporary addition for jnacl (OSGi included in snapshot) -->
-    <profiles>
-        <profile>
-            <id>allow-snapshots</id>
-            <activation><activeByDefault>true</activeByDefault></activation>
-            <repositories>
-                <repository>
-                    <id>snapshots-repo</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                    <releases><enabled>false</enabled></releases>
-                    <snapshots><enabled>true</enabled></snapshots>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
+    <dependencyManagement>
+        <dependencies>
+            <!-- PubSubAdmin modules -->
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.spi</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.discovery.etcd</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.serialization.json</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.topologymanager</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.psa.zeromq</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.examples.pubsub.common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.examples.pubsub.publisher</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.inaetics.pubsub</groupId>
+                <artifactId>org.inaetics.pubsub.examples.pubsub.subscriber</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-    <dependencies>
-        <!-- OSGi framework + API -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.framework</artifactId>
-            <version>5.6.10</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr</artifactId>
-            <version>2.0.12</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>${osgi.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.annotation</artifactId>
-            <version>${osgi.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
-            <version>${osgi.version}</version>
-        </dependency>
+            <!-- OSGi framework + API -->
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.framework</artifactId>
+                <version>5.6.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.annotation</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.osgi</groupId>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>${osgi.version}</version>
+            </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.5</version>
-        </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.metatype</artifactId>
+                <version>1.1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.configadmin</artifactId>
+                <version>1.6.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.eventadmin</artifactId>
+                <version>1.3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.log</artifactId>
+                <version>1.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.gogo.runtime</artifactId>
+                <version>1.0.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.gogo.shell</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.gogo.command</artifactId>
+                <version>1.0.2</version>
+            </dependency>
 
-        <!-- Jackson (serialization) -->
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
-        </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.dependencymanager</artifactId>
+                <version>4.4.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.dependencymanager.shell</artifactId>
+                <version>4.0.6</version>
+            </dependency>
 
-        <!-- Required for remote services -->
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.metatype</artifactId>
-            <version>1.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.configadmin</artifactId>
-            <version>1.6.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.eventadmin</artifactId>
-            <version>1.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.http.jetty</artifactId>
-            <version>2.2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.log</artifactId>
-            <version>1.0.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.dependencymanager</artifactId>
-            <version>4.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.dependencymanager.shell</artifactId>
-            <version>4.0.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.gogo.runtime</artifactId>
-            <version>1.0.10</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.gogo.shell</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.gogo.command</artifactId>
-            <version>1.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.http.servlet-api</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.service.remoteserviceadmin</artifactId>
-            <version>1.1.0</version>
-        </dependency>
+            <!-- etcd dependencies -->
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore-osgi</artifactId>
+                <version>4.4.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-osgi</artifactId>
+                <version>4.5.3</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.8</version>
+            </dependency>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.dependencymanager.annotation</artifactId>
-            <version>4.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>biz.aQute.bnd</groupId>
-            <artifactId>biz.aQute.bndlib</artifactId>
-            <version>2.4.1</version>
-            <scope>provided</scope>
-        </dependency>
+            <!-- ZeroMQ -->
+            <dependency>
+                <groupId>org.zeromq</groupId>
+                <artifactId>jeromq</artifactId>
+                <version>0.4.3</version>
+            </dependency>
+            <dependency>
+                <groupId>eu.neilalexander</groupId>
+                <artifactId>jnacl</artifactId>
+                <version>1.0.0</version>
+            </dependency>
 
-        <!-- Required for testing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
+            <!-- Required for testing -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.11</version>
+                <scope>test</scope>
+            </dependency>
 
-    </dependencies>
+        </dependencies>
+    </dependencyManagement>
 
     <modules>
         <module>pubsub.api</module>

--- a/pubsub.api/pom.xml
+++ b/pubsub.api/pom.xml
@@ -12,4 +12,11 @@
     <artifactId>org.inaetics.pubsub.api</artifactId>
     <name>INAETICS PubSub API</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/pubsub.discovery.etcd/pom.xml
+++ b/pubsub.discovery.etcd/pom.xml
@@ -34,40 +34,47 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.spi</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-osgi</artifactId>
-            <version>4.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
-            <version>4.5.3</version>
         </dependency>
 
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
         </dependency>
+
+<!--        <dependency>-->
+<!--            <groupId>org.codehaus.jackson</groupId>-->
+<!--            <artifactId>jackson-core-asl</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.codehaus.jackson</groupId>-->
+<!--            <artifactId>jackson-mapper-asl</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
         </dependency>
     </dependencies>
 </project>

--- a/pubsub.discovery.etcd/src/main/java/org/inaetics/pubsub/impl/discovery/etcd/EtcdDiscovery.java
+++ b/pubsub.discovery.etcd/src/main/java/org/inaetics/pubsub/impl/discovery/etcd/EtcdDiscovery.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.inaetics.pubsub.impl.discovery.etcd;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.inaetics.pubsub.spi.discovery.AnnounceEndpointListener;
 import org.inaetics.pubsub.spi.discovery.DiscoveredEndpointListener;
 import org.inaetics.pubsub.spi.utils.Constants;

--- a/pubsub.discovery.etcd/src/main/java/org/inaetics/pubsub/impl/discovery/etcd/Utils.java
+++ b/pubsub.discovery.etcd/src/main/java/org/inaetics/pubsub/impl/discovery/etcd/Utils.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.inaetics.pubsub.impl.discovery.etcd;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.codehaus.jackson.JsonNode;
 
 import java.util.Iterator;
 import java.util.Properties;
@@ -37,11 +37,11 @@ public class Utils {
         Properties result = null;
         if (node != null && node.isObject()) {
             result = new Properties();
-            for (Iterator<String> it = node.getFieldNames(); it.hasNext(); ) {
+            for (Iterator<String> it = node.fieldNames(); it.hasNext(); ) {
                 String name = it.next();
                 JsonNode val = node.get(name);
                 if (val != null && val.isTextual()) {
-                    result.put(name, val.getTextValue());
+                    result.put(name, val.textValue());
                 }
             }
         }

--- a/pubsub.psa.zeromq/pom.xml
+++ b/pubsub.psa.zeromq/pom.xml
@@ -34,22 +34,28 @@ DynamicImport-Package: *
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.zeromq</groupId>
             <artifactId>jeromq</artifactId>
-            <version>0.4.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.zeromq</groupId>
+                    <artifactId>jnacl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.zeromq</groupId>
+            <groupId>eu.neilalexander</groupId>
             <artifactId>jnacl</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pubsub.serialization.json/pom.xml
+++ b/pubsub.serialization.json/pom.xml
@@ -34,23 +34,24 @@ DynamicImport-Package: *
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.spi</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pubsub.spi/pom.xml
+++ b/pubsub.spi/pom.xml
@@ -14,15 +14,24 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.inaetics.pubsub</groupId>
-            <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.annotation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.4.1</version>
-            <scope>test</scope>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.inaetics.pubsub</groupId>
+            <artifactId>org.inaetics.pubsub.api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/pubsub.topologymanager/pom.xml
+++ b/pubsub.topologymanager/pom.xml
@@ -33,12 +33,14 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.api</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.inaetics.pubsub</groupId>
             <artifactId>org.inaetics.pubsub.spi</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
PR to address enhancement #6 

Summary of changes:
Consolidated dependency management in parent
Moved dependencies towards specific modules where they are used (rather then having them being inherited from the parent)
Replaced Jackson from org.codehaus.jackson with successor from com.fasterxml.jackson.core
Simplified deployment project by using bnd-export-maven-plugin's resolve capability, rather then having to specify each bundle that would be needed at runtime
Removed various dependencies that were not used (e.g. scr, remoteserviceadmin, etc)
Simplified launcher generation