### PR TITLE
Interface improvements PubSubAdmin API

### DIFF
--- a/examples/pubsub/publisher/src/main/java/org/inaetics/pubsub/examples/pubsub/publisher/DemoPublisher.java
+++ b/examples/pubsub/publisher/src/main/java/org/inaetics/pubsub/examples/pubsub/publisher/DemoPublisher.java
@@ -19,7 +19,7 @@ import org.inaetics.pubsub.examples.pubsub.common.PointOfInterrest;
 
 public class DemoPublisher {
 
-    private volatile Publisher publisher;
+    private volatile Publisher<PointOfInterrest> publisher;
 
     private Location loc;
     private PointOfInterrest poi;

--- a/examples/pubsub/subscriber/src/main/java/org/inaetics/pubsub/examples/pubsub/subscriber/DemoSubscriber.java
+++ b/examples/pubsub/subscriber/src/main/java/org/inaetics/pubsub/examples/pubsub/subscriber/DemoSubscriber.java
@@ -14,11 +14,6 @@ public class DemoSubscriber implements Subscriber<Location> {
     }
 
     @Override
-    public void init() {
-        //nop
-    }
-
-    @Override
     public void receive(Location location) {
         System.out.printf("Recv location [%s, %s]\n", location.getLat(), location.getLon());
     }

--- a/pubsub.api/src/main/java/org/inaetics/pubsub/api/Publisher.java
+++ b/pubsub.api/src/main/java/org/inaetics/pubsub/api/Publisher.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.inaetics.pubsub.api;
 
-public interface Publisher {
+public interface Publisher<T> {
 
     String PUBSUB_TOPIC = Constants.TOPIC_KEY;
     String PUBSUB_SCOPE = Constants.SCOPE_KEY;
 
-    void send(Object msg);
+    void send(T msg);
 }

--- a/pubsub.api/src/main/java/org/inaetics/pubsub/api/Subscriber.java
+++ b/pubsub.api/src/main/java/org/inaetics/pubsub/api/Subscriber.java
@@ -19,6 +19,5 @@ public interface Subscriber<T> {
     String PUBSUB_SCOPE = Constants.SCOPE_KEY;
 
     Class<T> receiveClass();
-    void init();
     void receive(T msg);
 }

--- a/pubsub.psa.zeromq/src/main/java/org/inaetics/pubsub/impl/pubsubadmin/zeromq/ZmqTopicReceiver.java
+++ b/pubsub.psa.zeromq/src/main/java/org/inaetics/pubsub/impl/pubsubadmin/zeromq/ZmqTopicReceiver.java
@@ -43,7 +43,6 @@ public class ZmqTopicReceiver {
         private final Subscriber subscriber;
         private final MultiMessageSubscriber multiMessageSubscriber;
         private final Collection<Class<?>> receiveClasses;
-        boolean initialized = false;
 
         public SubscriberEntry(long svcId, Subscriber subscriber, Class<?> receiveClass) {
             this.svcId = svcId;
@@ -240,15 +239,6 @@ public class ZmqTopicReceiver {
                     Object msg = serializer.deserialize(msgClass.getName(), payloadMsg.getData());
                     synchronized (subscribers) {
                         for (SubscriberEntry entry : subscribers.values()) {
-                            if (!entry.initialized) {
-                                if (entry.subscriber != null) {
-                                    entry.subscriber.init();
-                                }
-                                if (entry.multiMessageSubscriber != null) {
-                                    entry.multiMessageSubscriber.init();
-                                }
-                                entry.initialized = true;
-                            }
                             for (Class<?> clazz : entry.receiveClasses) {
                                 if (msgClass.equals(clazz)) {
                                     if (entry.subscriber != null) {


### PR DESCRIPTION
Subscriber: removed init() method from interface; purpose unclear, noise for implementors.
Publisher: added generic T to signature, with the sole purpose to be _able_ to enforce the type of messages produced