### PR TITLE
Various improvements to PubSubTopologyManager

### DIFF
--- a/deploy/pom.xml
+++ b/deploy/pom.xml
@@ -108,6 +108,15 @@
             <artifactId>org.apache.felix.log</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,23 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Logging dependencies -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.26</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.3</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/pubsub.topologymanager/pom.xml
+++ b/pubsub.topologymanager/pom.xml
@@ -42,5 +42,9 @@ Bundle-Activator: ${classes;IMPLEMENTS;org.osgi.framework.BundleActivator}
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.dependencymanager</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
1) Improved method of detecting changes and triggering the TopologyManager Thread, such that when resources need to be created we do not rely on the 15s timeout for resources to be created.
   Before this patch a notifyAll() whilst the TopologyManager Thread was already busy processing another configuration change, would not immediately re-trigger the configuration loop, resulting in having to wait 15s for the resources to be created.

 2) Moved the creation of Sender/Receiver outside the senderAndReceivers synchronized block. This to keep the mutex limited to protecting the administration itself, and not the interaction with PSA-external code. The latter may, in some cases, result in deadlocks.